### PR TITLE
Combination of work for Rails8 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,7 +44,7 @@ jobs:
       fail-fast: false
       matrix:
         # https://ruby-lang.org/en/downloads/branches
-        ruby: ["3.3", "3.2", "3.1"]
+        ruby: ["3.3", "3.2"]
         # https://www.postgresql.org/support/versioning/
         pg: [12-master, 13-master, 14-master, 15-master, 16-master]
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,6 @@ Gemfile.lock
 /travis/*.lock
 /test/database_local.yml
 .idea
-debug.log
+debug.log*
 /test/db/*
+/test/storage/

--- a/History.md
+++ b/History.md
@@ -1,3 +1,8 @@
+### 10.0.1 / 2024-11-15
+
+* Fix `Quoting` of RGeo objects #417 (JamesChevalier)
+* Fix loading issue in multi-db environments #418 (dorner)
+
 ### 10.0.0 / 2024-11-04
 
 * ActiveRecord 7.2 support #405

--- a/History.md
+++ b/History.md
@@ -1,7 +1,7 @@
 ### 10.0.1 / 2024-11-15
 
-* Fix `Quoting` of RGeo objects #417 (JamesChevalier)
-* Fix loading issue in multi-db environments #418 (dorner)
+* Fix `Quoting` of RGeo objects (JamesChevalier) #417
+* Fix loading issue in multi-db environments (dorner) #418
 
 ### 10.0.0 / 2024-11-04
 

--- a/lib/active_record/connection_adapters/postgis/version.rb
+++ b/lib/active_record/connection_adapters/postgis/version.rb
@@ -3,7 +3,7 @@
 module ActiveRecord
   module ConnectionAdapters
     module PostGIS
-      VERSION = "10.0.0"
+      VERSION = "10.0.1"
     end
   end
 end

--- a/lib/active_record/connection_adapters/postgis_adapter.rb
+++ b/lib/active_record/connection_adapters/postgis_adapter.rb
@@ -161,5 +161,4 @@ module ActiveRecord
     spatial_ref_sys
     topology
   ]
-  Tasks::DatabaseTasks.register_task(/postgis/, "ActiveRecord::Tasks::PostgreSQLDatabaseTasks")
 end

--- a/lib/activerecord-postgis-adapter.rb
+++ b/lib/activerecord-postgis-adapter.rb
@@ -4,3 +4,4 @@ require 'active_record'
 require "active_record/connection_adapters"
 require "rgeo/active_record"
 ActiveRecord::ConnectionAdapters.register("postgis", "ActiveRecord::ConnectionAdapters::PostGISAdapter", "active_record/connection_adapters/postgis_adapter")
+ActiveRecord::Tasks::DatabaseTasks.register_task(/postgis/, "ActiveRecord::Tasks::PostgreSQLDatabaseTasks")

--- a/test/excludes/SchemaDumperTest.rb
+++ b/test/excludes/SchemaDumperTest.rb
@@ -3,3 +3,4 @@ exclude "test_schema_dump_when_changing_datetime_type_for_an_existing_app", TRIA
 if ActiveRecord::Base.lease_connection.pool.server_version(ActiveRecord::Base.lease_connection) < 15_00_00
   exclude "test_schema_dumps_unique_constraints", TRIAGE_MSG
 end
+exclude "test_foreign_keys_are_dumped_at_the_bottom_to_circumvent_dependency_issues", TRIAGE_MSG


### PR DESCRIPTION
Hello there,

I went through rgeo/activerecord-postgis-adapter#419 and rgeo/activerecord-postgis-adapter#421 to make this PR.
I have then 
- merged them with master
- excluded one test from activerecord that would not pass because of a Postgis related constraint that is interfering with an expectation due to the way it was coded.
- dismissed a change to AR_VERSION env variable on github workflow which is not needed. There is code to pick the right version from the installed gems on `test/rake_helper.rb`